### PR TITLE
Autocomplete overlaps picture button on front page + small movie card adjustments

### DIFF
--- a/app/assets/stylesheets/components/_actor_card.scss
+++ b/app/assets/stylesheets/components/_actor_card.scss
@@ -6,9 +6,11 @@
 .actor-cards {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  grid-gap: 20px;
+  grid-gap: 10px;
   position: relative;
   width: 100%;
+  margin-top: 10px;
+  margin-bottom: 10px;
 }
 
 .actor-card-img {

--- a/app/assets/stylesheets/components/_image_upload.scss
+++ b/app/assets/stylesheets/components/_image_upload.scss
@@ -12,6 +12,11 @@
   color: #face66;
   font-size: 60px;
   padding: 10px;
+  position: fixed;
+  top: 59%;
+  left: 50%;
+  transform: translate(-50%, 0);
+  z-index: -1;
   &:hover {
     cursor: pointer;
     color: #cd20f8;

--- a/app/assets/stylesheets/components/_movie_card.scss
+++ b/app/assets/stylesheets/components/_movie_card.scss
@@ -26,5 +26,5 @@
 
 .film-option {
   cursor: pointer;
-  background-color: rgba(255, 255, 255, 0.2);
+  background-color: rgba(255, 255, 255, 0.75);
 }


### PR DESCRIPTION
Movie cards in front page overlap the picture button now and are better readable with the new background (reduced transparancy). Also added some margin on top and bottom to the movie cards, it looks nicer now on the pre result page when the user is typing a second movie and gets movie suggestions from autocomplete.