### PR TITLE
Moving picture icon on front page fixed

### DIFF
--- a/app/assets/stylesheets/components/_image_upload.scss
+++ b/app/assets/stylesheets/components/_image_upload.scss
@@ -12,10 +12,7 @@
   color: #face66;
   font-size: 60px;
   padding: 10px;
-  position: fixed;
-  top: 59%;
-  left: 50%;
-  transform: translate(-50%, 0);
+  margin-bottom: 20px;
   z-index: -1;
   &:hover {
     cursor: pointer;


### PR DESCRIPTION
The picture icon on the front page shouldn't move now when scrolling the side. But it doesn't get overlapped from the autocomplete suggestions anymore.